### PR TITLE
Convert year to "first release date"

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -18,7 +18,7 @@ class MoviesController < ApplicationController
     @movies = @movies.where("general_reviews_count >= ?", @min_reviews)
     @movies = @movies.joins(:genres).where(genres: {id: @genre_id}) if @genre_id
     @movies = @movies.where("rating >= ?", @min_rating) if @min_rating
-    @movies = @movies.where("year >= ?", @min_year) if @min_year
+    @movies = @movies.where("first_release_date >= ?", "#{@min_year}-01-01") if @min_year
     @movies = @movies.joins(:annotation).where(annotations: {watched: false, ignore: false}).order("watchlist DESC") if @watchable
     @movies = @movies.order("#{@sorting_field} DESC") if @sorting_field
 

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -2,7 +2,7 @@ module MoviesHelper
   MOVIES_PER_PAGE = 30
 
   SORT_MAPPING = {
-    "Release date" => "year",
+    "Release date" => "first_release_date",
     "Rating"       => "rating",
   }.freeze
 

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -9,4 +9,8 @@ class Movie < ActiveRecord::Base
   delegate :watched,   to: :annotation
   delegate :ignore,    to: :annotation
   delegate :watchlist, to: :annotation
+
+  def year
+    first_release_date[0, 4].to_i
+  end
 end

--- a/db/migrate/20180826183458_add_first_release_date_to_movies.rb
+++ b/db/migrate/20180826183458_add_first_release_date_to_movies.rb
@@ -1,0 +1,5 @@
+class AddFirstReleaseDateToMovies < ActiveRecord::Migration[5.1]
+  def change
+    add_column :movies, :first_release_date, :string, null: false
+  end
+end

--- a/db/migrate/20180827101934_drop_movies_year.rb
+++ b/db/migrate/20180827101934_drop_movies_year.rb
@@ -1,0 +1,5 @@
+class DropMoviesYear < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :movies, :year
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,10 +57,10 @@ ActiveRecord::Schema.define(version: 20161209195015) do
     t.string   "title",                 null: false
     t.text     "synopsis",              null: false
     t.integer  "rating"
-    t.integer  "year",                  null: false
     t.datetime "updated_on",            null: false
     t.string   "url_path",              null: false
     t.integer  "general_reviews_count", null: false
+    t.string   "first_release_date",    null: false
   end
 
   add_index "movies", ["url_path"], name: "index_movies_on_url_path", unique: true


### PR DESCRIPTION
Using a full date is fundamental for sorting.

The term "first" refers to the earliest date available, either theaters or dvd.